### PR TITLE
Issue Viewing Improvements

### DIFF
--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -18,8 +18,8 @@
 .title {
 	text-align: center;
 	color: white;
-	margin-top: 5px;
-	font-size: 30px;
+	margin-top: 8px;
+	font-size: 26px;
 	display: inline-block;
 }
 

--- a/app/assets/stylesheets/lines.scss
+++ b/app/assets/stylesheets/lines.scss
@@ -77,23 +77,35 @@
 
 		a { text-decoration: none; }
 	}
-	.api-id {
-		background: lightgrey;
-		color: #535353;
-		padding: 2px 6px;
-		border-radius: 3px;
-	}
-	.line-swatch {
-		width: 20px;
-		height: 20px;
-		border-radius: 50px;
-	}
 	span {
 		padding-left: 5px;
 		vertical-align: middle;
 		display: table-cell;
 	}
 }
+
+.api-id {
+	background: lightgrey;
+	color: #535353;
+	padding: 2px 6px;
+	border-radius: 3px;
+}
+.line-swatch {
+	width: 20px;
+	height: 20px;
+	border-radius: 50px;
+}
+
+.stop-title {
+	.line-tile {
+		display: inline-block;
+	
+		&:first-of-type { margin-left: 5px; }
+		.api-id, .line-swatch { font-size: 12px; }
+	}
+}
+
+.issue-title { margin-bottom: 5px; }
 
 .fav-star {
 	width: 20px;

--- a/app/controllers/stops_controller.rb
+++ b/app/controllers/stops_controller.rb
@@ -1,4 +1,5 @@
 class StopsController < ApplicationController
   def show
+    @stop = Stop.find(params[:stop_id])
   end
 end

--- a/app/views/stops/_show.html.erb
+++ b/app/views/stops/_show.html.erb
@@ -5,7 +5,7 @@
 		<%= render "lines/tiles", lines: stop.lines %>
 	<% end %>
 	<span>
-		<%= stop.name %>
+		<%= link_to stop.name, stop %>
 		<% if user_signed_in? %>
 			<% if current_user.favorites.include?(stop) %>
 				<%= link_to unfavorite_path(stop) do %>

--- a/app/views/stops/_show_with_issues.html.erb
+++ b/app/views/stops/_show_with_issues.html.erb
@@ -1,15 +1,18 @@
 <% unless stop.lines.empty? %>
 <div class="stops-container">
     <%= render "stops/show", stop: stop %>
-    <div class="issue-container">
-        <ul class="ul-dash">
-            <% stop.issues.each do |issue| %>
-                <li class="li-dash">
-                    <span class="issue-title"><%= issue.types %></span>
-                    <span class="issue-time"><%= time_ago_in_words(DateTime.now - 10.minute) %> ago</span>
-                </li>
-            <% end %>
-        </ul>
-    </div>
+    
+    <% unless stop.issues.empty? # only show issue container if there are issues to show %>
+        <div class="issue-container">
+            <ul class="ul-dash">
+                <% stop.issues.each do |issue| %>
+                    <li class="li-dash">
+                        <span class="issue-title"><%= issue.types %></span>
+                        <span class="issue-time"><%= time_ago_in_words(DateTime.now - 10.minute) %> ago</span>
+                    </li>
+                <% end %>
+            </ul>
+        </div>
+    <% end %>
 </div>
 <% end %>

--- a/app/views/stops/_show_with_issues.html.erb
+++ b/app/views/stops/_show_with_issues.html.erb
@@ -1,18 +1,18 @@
 <% unless stop.lines.empty? %>
 <div class="stops-container">
-    <%= render "stops/show", stop: stop %>
-    
-    <% unless stop.issues.empty? # only show issue container if there are issues to show %>
-        <div class="issue-container">
-            <ul class="ul-dash">
-                <% stop.issues.each do |issue| %>
-                    <li class="li-dash">
-                        <span class="issue-title"><%= issue.types %></span>
-                        <span class="issue-time"><%= time_ago_in_words(DateTime.now - 10.minute) %> ago</span>
-                    </li>
-                <% end %>
-            </ul>
-        </div>
-    <% end %>
+	<%= render "stops/show", stop: stop %>
+	
+	<% unless stop.issues.empty? # only show issue container if there are issues to show %>
+		<div class="issue-container">
+			<ul class="ul-dash">
+				<% stop.issues.each do |issue| %>
+					<li class="li-dash">
+						<span class="issue-title"><%= issue.types %></span>
+						<span class="issue-time"><%= time_ago_in_words(DateTime.now - 10.minute) %> ago</span>
+					</li>
+				<% end %>
+			</ul>
+		</div>
+	<% end %>
 </div>
 <% end %>

--- a/app/views/stops/show.html.erb
+++ b/app/views/stops/show.html.erb
@@ -1,0 +1,22 @@
+<div class="page-container">
+	<h3 class="stop-title">
+		<%= @stop.name %>
+		<%= render "lines/tiles", lines: @stop.lines %>
+	</h3>
+
+	<h4 class="issue-title">Issues</h4>
+	<% unless @stop.issues.empty? # only show issue container if there are issues to show %>
+		<div class="issue-container">
+			<ul class="ul-dash">
+				<% @stop.issues.each do |issue| %>
+					<li class="li-dash">
+						<span class="issue-title"><%= issue.types %></span>
+						<span class="issue-time"><%= time_ago_in_words(DateTime.now - 10.minute) %> ago</span>
+					</li>
+				<% end %>
+			</ul>
+		</div>
+	<% else %>
+		There are no issues!
+	<% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   match "/lines/:line_id/get_stops" => 'lines#get_stops', :as => :get_stops, via: [:get, :post]
 
-  get "/stops/:stop_id" => 'stops#show', :as => :stops
+  get "/stops/:stop_id" => 'stops#show', :as => :stop
 
   get "/search" => 'pages#search', :as => :search
 


### PR DESCRIPTION
I've fixed an issue on the homepage where lines would show up if a stop had no issues, I've setup individual stop pages to display issues on stops, and made all displays of stops link to the individual stop page.

Comparison screenshots of homepage (Old VS New respectively):

<img src="https://cloud.githubusercontent.com/assets/3187531/26611933/1e263c7a-4577-11e7-8f51-c278bca10e20.png" width=47% align="left">
<img src="https://cloud.githubusercontent.com/assets/3187531/26612060/ff87f848-4577-11e7-9113-9020dec51df1.png" width=47% align="left">

An individual stop page:


![screenshot from 2017-05-30 20-38-46](https://cloud.githubusercontent.com/assets/3187531/26612072/0a3ce050-4578-11e7-92cc-e939517e9e73.png)

Also fixed search being missing due to long "Transit Network title". This bug was on `master` but was not deployed to production, which has a different title.
