### PR TITLE
Fix Issue Time Being Consistently 10 Minutes Ago

### DIFF
--- a/app/views/issues/_show_list.html.erb
+++ b/app/views/issues/_show_list.html.erb
@@ -1,0 +1,10 @@
+<div class="issue-container">
+	<ul class="ul-dash">
+		<% issues.each do |issue| %>
+			<li class="li-dash">
+				<span class="issue-title"><%= issue.types %></span>
+				<span class="issue-time"><%= time_ago_in_words(issue.created_at) %> ago</span>
+			</li>
+		<% end %>
+	</ul>
+</div>

--- a/app/views/stops/_show_with_issues.html.erb
+++ b/app/views/stops/_show_with_issues.html.erb
@@ -3,16 +3,7 @@
 	<%= render "stops/show", stop: stop %>
 	
 	<% unless stop.issues.empty? # only show issue container if there are issues to show %>
-		<div class="issue-container">
-			<ul class="ul-dash">
-				<% stop.issues.each do |issue| %>
-					<li class="li-dash">
-						<span class="issue-title"><%= issue.types %></span>
-						<span class="issue-time"><%= time_ago_in_words(issue.created_at) %> ago</span>
-					</li>
-				<% end %>
-			</ul>
-		</div>
+		<%= render partial: "issues/show_list", locals: {issues: stop.issues} %>
 	<% end %>
 </div>
 <% end %>

--- a/app/views/stops/_show_with_issues.html.erb
+++ b/app/views/stops/_show_with_issues.html.erb
@@ -8,7 +8,7 @@
 				<% stop.issues.each do |issue| %>
 					<li class="li-dash">
 						<span class="issue-title"><%= issue.types %></span>
-						<span class="issue-time"><%= time_ago_in_words(DateTime.now - 10.minute) %> ago</span>
+						<span class="issue-time"><%= time_ago_in_words(issue.created_at) %> ago</span>
 					</li>
 				<% end %>
 			</ul>

--- a/app/views/stops/show.html.erb
+++ b/app/views/stops/show.html.erb
@@ -11,7 +11,7 @@
 				<% @stop.issues.each do |issue| %>
 					<li class="li-dash">
 						<span class="issue-title"><%= issue.types %></span>
-						<span class="issue-time"><%= time_ago_in_words(DateTime.now - 10.minute) %> ago</span>
+						<span class="issue-time"><%= time_ago_in_words(issue.created_at) %> ago</span>
 					</li>
 				<% end %>
 			</ul>

--- a/app/views/stops/show.html.erb
+++ b/app/views/stops/show.html.erb
@@ -6,16 +6,7 @@
 
 	<h4 class="issue-title">Issues</h4>
 	<% unless @stop.issues.empty? # only show issue container if there are issues to show %>
-		<div class="issue-container">
-			<ul class="ul-dash">
-				<% @stop.issues.each do |issue| %>
-					<li class="li-dash">
-						<span class="issue-title"><%= issue.types %></span>
-						<span class="issue-time"><%= time_ago_in_words(issue.created_at) %> ago</span>
-					</li>
-				<% end %>
-			</ul>
-		</div>
+		<%= render partial: "issues/show_list", locals: {issues: @stop.issues} %>
 	<% else %>
 		There are no issues!
 	<% end %>


### PR DESCRIPTION
This pull request fixes the time displayed on issues consistently being listed as "10 minutes ago" and not using the issue's `created_at` attribute. It also refactors some duplicate code that displays a list of issues, which will probably be used enough that it should be modularized into one place.