### PR TITLE
Move to Transitland

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 
 # Ignore Sublime files
 *.sublime*
+
+# Ignore .env from dot-env, used for local config
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,6 @@ gem "time_difference"
 
 # Useful for big data transactions
 gem "activerecord-import"
+
+# dotenv (https://github.com/bkeepers/dotenv), which lets us store config in .env
+gem 'dotenv-rails', :groups => [:development, :test]

--- a/Gemfile
+++ b/Gemfile
@@ -79,3 +79,6 @@ gem "activerecord-import"
 
 # dotenv (https://github.com/bkeepers/dotenv), which lets us store config in .env
 gem 'dotenv-rails', :groups => [:development, :test]
+
+# Add httpparty (https://github.com/jnunemaker/httparty) for simpler HTTP
+gem 'httparty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
       multi_json
       rake
       rubyzip (~> 1.1)
+    httparty (0.15.6)
+      multi_xml (>= 0.5.2)
     i18n (0.8.1)
     jbuilder (2.6.3)
       activesupport (>= 3.0.0, < 5.2)
@@ -99,6 +101,7 @@ GEM
     mini_portile2 (2.1.0)
     minitest (5.10.1)
     multi_json (1.12.1)
+    multi_xml (0.5.5)
     mysql2 (0.3.21)
     nio4r (1.2.1)
     nokogiri (1.7.0.1)
@@ -194,6 +197,7 @@ DEPENDENCIES
   dotenv-rails
   geokit-rails
   gtfs
+  httparty
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,10 @@ GEM
       railties (>= 4.1.0, < 5.1)
       responders
       warden (~> 1.2.3)
+    dotenv (2.2.1)
+    dotenv-rails (2.2.1)
+      dotenv (= 2.2.1)
+      railties (>= 3.2, < 5.2)
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.9.17)
@@ -187,6 +191,7 @@ DEPENDENCIES
   byebug
   coffee-rails (~> 4.2)
   devise
+  dotenv-rails
   geokit-rails
   gtfs
   jbuilder (~> 2.5)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,18 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
     
 ## Making a New App
-### Loading GTFS Data
+
+### Loading Data from transit.land
+
+Start by finding the transit network operator you want to setup a site for from [transit.land's feed registry](https://transit.land/feed-registry/). Grab the `onestop_id` for the desired operator.
+
+Then run `rake transit:set_up_transitland TLAND_AGENCY_ONESTOP_ID=%onestop_id%`
+
+Alternatively, the transit agency's onestop_id can be pulled from environment variables, so setting the `TLAND_AGENCY_ONESTOP_ID` environment variable to your desired onestop_id and then running `rake transit:set_up_transitland` will also work.
+
+### Loading GTFS Data (Deprecated)
+**Note:** This method is now deprecated for the transit.land data import mentioned above
+
 Get the URL for the GTFS data, which we'll call _data_url_.
 
 Download the file using wget - `wget '_data_url_'`

--- a/app/assets/stylesheets/lines.scss
+++ b/app/assets/stylesheets/lines.scss
@@ -68,10 +68,9 @@
 .stop-partial {
 	min-height: 30px;
 	margin: 5px 0px;
-	display: table;
 
 	.line-tile {
-		display: table-cell;
+		display: inline-block;
 		vertical-align: middle;
 		padding: 2px;
 
@@ -80,7 +79,7 @@
 	span {
 		padding-left: 5px;
 		vertical-align: middle;
-		display: table-cell;
+		display: inline-block;
 	}
 }
 

--- a/app/assets/stylesheets/lines.scss
+++ b/app/assets/stylesheets/lines.scss
@@ -79,7 +79,6 @@
 	span {
 		padding-left: 5px;
 		vertical-align: middle;
-		display: inline-block;
 	}
 }
 

--- a/app/controllers/lines_controller.rb
+++ b/app/controllers/lines_controller.rb
@@ -1,6 +1,6 @@
 class LinesController < ApplicationController
   def index
-    @lines = Line.all.order(:system_type)
+    @lines = Line.all.sort_by { |l| -l.name.to_i }.sort_by { |l| l.vehicle_type }.reverse!
   end
 
   def show

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,7 +15,7 @@ class PagesController < ApplicationController
 
   def search
     @result_lines = Line.where("name LIKE ? OR route_long_name LIKE ?", "%#{params[:q]}%", "%#{params[:q]}%")
-    @result_stops = Stop.includes(:lines).where("stops.name LIKE ?", "%#{params[:q]}%").order("lines.system_type")
+    @result_stops = Stop.includes(:lines).where("stops.name LIKE ?", "%#{params[:q]}%").order("lines.vehicle_type DESC")
   end
 
   def valid_page?

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -14,8 +14,8 @@ class PagesController < ApplicationController
   end
 
   def search
-    @result_lines = Line.where("name like ?", "%#{params[:q]}%")
-    @result_stops = Stop.includes(:lines).where("stops.name LIKE ? AND stops.twin_stop_id IS NULL AND lines.system_type IS NOT NULL", "%#{params[:q]}%").order("lines.system_type")
+    @result_lines = Line.where("name LIKE ? OR route_long_name LIKE ?", "%#{params[:q]}%", "%#{params[:q]}%")
+    @result_stops = Stop.includes(:lines).where("stops.name LIKE ?", "%#{params[:q]}%").order("lines.system_type")
   end
 
   def valid_page?

--- a/app/models/line.rb
+++ b/app/models/line.rb
@@ -1,4 +1,16 @@
 class Line < ApplicationRecord
   has_many :issues
   has_and_belongs_to_many :stops, :foreign_key => 'line_onestop_id', :association_foreign_key => 'stop_onestop_id'
+
+  # Returns the longest available name
+  def long_name
+    route_long_name ? route_long_name : name
+  end
+
+  # Returns the short name if it is different from the long name
+  # Ex: short_name({route_long_name: "Ashland", name: "9"}) => "9"
+  # Ex: short_name({route_long_name: "Red Line", name: "Red Line"}) => nil
+  def short_name
+    route_long_name != name ? name : nil
+  end
 end

--- a/app/models/line.rb
+++ b/app/models/line.rb
@@ -1,4 +1,4 @@
 class Line < ApplicationRecord
   has_many :issues
-  has_and_belongs_to_many :stops
+  has_and_belongs_to_many :stops, :foreign_key => 'line_onestop_id', :association_foreign_key => 'stop_onestop_id'
 end

--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -1,6 +1,6 @@
 class Stop < ApplicationRecord
   has_many :issues
-  has_and_belongs_to_many :lines
+  has_and_belongs_to_many :lines, :foreign_key => 'stop_onestop_id', :association_foreign_key => 'line_onestop_id'
   belongs_to :twin_stop, class_name: "Stop", required: false
   has_and_belongs_to_many :users
 

--- a/app/views/issues/_form.html.erb
+++ b/app/views/issues/_form.html.erb
@@ -13,7 +13,7 @@
 
   <div class="field-issue">
     <%= f.label :line_id %><br>
-    <%= f.collection_select(:line_id, Line.order(:system_type, :name), :id, :name,
+    <%= f.collection_select(:line_id, Line.order('vehicle_type DESC, name'), :id, :name,
       {prompt: 'Select Line'},
       {:class => "new-issue-line"}
     ) %>

--- a/app/views/lines/_show.html.erb
+++ b/app/views/lines/_show.html.erb
@@ -1,6 +1,6 @@
 <div class="stop-partial">
 	<%= render "lines/tiles", lines: [line] %>
 	<span>
-		<%= link_to(line.name, line_path(line)) %><br>
+		<%= link_to(line.long_name, line_path(line)) %><br>
 	</span>
 </div>

--- a/app/views/lines/_tiles.html.erb
+++ b/app/views/lines/_tiles.html.erb
@@ -5,7 +5,7 @@
 				<% if line.color %>
 					<div class="line-swatch" style="background: #<%= line.color %>"></div>
 				<% else %>
-					<div class="api-id"><%= line.api_id %></div>
+					<div class="api-id"><%= line.name %></div>
 				<% end %>
 			<% end %>
 		</div>

--- a/app/views/lines/show.html.erb
+++ b/app/views/lines/show.html.erb
@@ -1,5 +1,10 @@
 <div class="line-cover">
-	<h3><%= @line.name %></h3>
+	<h3>
+		<%= @line.long_name %>
+		<% if @line.short_name %>
+			(<%= @line.short_name %>)
+		<% end %>
+	</h3>
 </div>
 <ul class="stop-list">
 	<% @line.stops.each do |stop| %>

--- a/db/migrate/20170822034621_add_onestop_id_to_lines.rb
+++ b/db/migrate/20170822034621_add_onestop_id_to_lines.rb
@@ -1,0 +1,6 @@
+class AddOnestopIdToLines < ActiveRecord::Migration[5.0]
+  def change
+    add_column :lines, :onestop_id, :string
+    add_index :lines, :onestop_id
+  end
+end

--- a/db/migrate/20170822035000_add_onestop_id_to_stops.rb
+++ b/db/migrate/20170822035000_add_onestop_id_to_stops.rb
@@ -1,0 +1,6 @@
+class AddOnestopIdToStops < ActiveRecord::Migration[5.0]
+  def change
+    add_column :stops, :onestop_id, :string
+    add_index :stops, :onestop_id
+  end
+end

--- a/db/migrate/20170822035019_move_lines_stops_to_onestop_ids.rb
+++ b/db/migrate/20170822035019_move_lines_stops_to_onestop_ids.rb
@@ -1,0 +1,9 @@
+class MoveLinesStopsToOnestopIds < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :lines_stops, :line_id, :line_onestop_id
+    change_column :lines_stops, :line_onestop_id, :string # Move to string
+
+    rename_column :lines_stops, :stop_id, :stop_onestop_id
+    change_column :lines_stops, :stop_onestop_id, :string # Move to string
+  end
+end

--- a/db/migrate/20170829123148_add_extra_transit_land_data_to_lines.rb
+++ b/db/migrate/20170829123148_add_extra_transit_land_data_to_lines.rb
@@ -1,0 +1,8 @@
+class AddExtraTransitLandDataToLines < ActiveRecord::Migration[5.0]
+  def change
+    add_column :lines, :vehicle_type, :string
+    add_column :lines, :wheelchair_accessible, :string
+    add_column :lines, :bikes_allowed, :string
+    rename_column :lines, :api_id, :route_long_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170307064700) do
+ActiveRecord::Schema.define(version: 20170822035019) do
 
   create_table "issues", force: :cascade do |t|
     t.integer  "stop_id"
@@ -32,14 +32,16 @@ ActiveRecord::Schema.define(version: 20170307064700) do
     t.string  "name"
     t.integer "system_type"
     t.string  "color"
+    t.string  "onestop_id"
     t.index ["api_id"], name: "index_lines_on_api_id"
+    t.index ["onestop_id"], name: "index_lines_on_onestop_id"
   end
 
   create_table "lines_stops", force: :cascade do |t|
-    t.integer "stop_id"
-    t.integer "line_id"
-    t.index ["line_id"], name: "index_lines_stops_on_line_id"
-    t.index ["stop_id"], name: "index_lines_stops_on_stop_id"
+    t.string "stop_onestop_id"
+    t.string "line_onestop_id"
+    t.index ["line_onestop_id"], name: "index_lines_stops_on_line_onestop_id"
+    t.index ["stop_onestop_id"], name: "index_lines_stops_on_stop_onestop_id"
   end
 
   create_table "stops", force: :cascade do |t|
@@ -48,7 +50,9 @@ ActiveRecord::Schema.define(version: 20170307064700) do
     t.decimal "longitude",    precision: 12, scale: 8
     t.decimal "lattitude",    precision: 12, scale: 8
     t.integer "twin_stop_id"
+    t.string  "onestop_id"
     t.index ["api_id"], name: "index_stops_on_api_id"
+    t.index ["onestop_id"], name: "index_stops_on_onestop_id"
   end
 
   create_table "stops_users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170822035019) do
+ActiveRecord::Schema.define(version: 20170829123148) do
 
   create_table "issues", force: :cascade do |t|
     t.integer  "stop_id"
@@ -28,13 +28,16 @@ ActiveRecord::Schema.define(version: 20170822035019) do
   end
 
   create_table "lines", force: :cascade do |t|
-    t.string  "api_id"
+    t.string  "route_long_name"
     t.string  "name"
     t.integer "system_type"
     t.string  "color"
     t.string  "onestop_id"
-    t.index ["api_id"], name: "index_lines_on_api_id"
+    t.string  "vehicle_type"
+    t.string  "wheelchair_accessible"
+    t.string  "bikes_allowed"
     t.index ["onestop_id"], name: "index_lines_on_onestop_id"
+    t.index ["route_long_name"], name: "index_lines_on_route_long_name"
   end
 
   create_table "lines_stops", force: :cascade do |t|

--- a/lib/tasks/create_transit.rake
+++ b/lib/tasks/create_transit.rake
@@ -18,8 +18,8 @@ namespace :transit do
     lines = []
     source.routes.each do |r|
       lines << Line.new(
-        api_id: r.id,
-        name: r.long_name,
+        name: r.id,
+        route_long_name: r.long_name,
         system_type: r.type,
         color: r.color,
       )
@@ -167,6 +167,10 @@ namespace :transit do
       route_response['routes'].each do |route_obj|
         line = Line.new
         line.name = route_obj['name']
+        line.route_long_name = route_obj['tags']['route_long_name']
+        line.vehicle_type = route_obj['vehicle_type']
+        line.wheelchair_accessible = route_obj['wheelchair_accessible']
+        line.bikes_allowed = route_obj['bikes_allowed']
         line.color = route_obj['color']
         line.onestop_id = route_obj['onestop_id']
 

--- a/lib/tasks/create_transit.rake
+++ b/lib/tasks/create_transit.rake
@@ -130,6 +130,30 @@ namespace :transit do
     puts "Reading Data Complete!"
   end
 
+  task set_up_transitland: :environment do
+    agency_onestop_id = ENV["TLAND_AGENCY_ONESTOP_ID"] # fetch the onestop_id of the agency
+
+    # View API endpoints for transitland here: https://transit.land/documentation/datastore/api-endpoints.html
+    root_url = 'https://transit.land/api/v1/'
+
+    # Iterate through routes, ignoring geometry
+    response = HTTParty.get(root_url + 'routes?served_by=' + agency_onestop_id + 'include_geometry=false')
+
+    # Iterate through stops by 500
+    per_page = 50
+    response = HTTParty.get(root_url + 'stops?per_page='  + per_page.TLAND_AGENCY_ONESTOP_ID + '&served_by=' + agency_onestop_id)
+    stop_response = JSON.parse response.body
+    p stop_response 
+
+    # Keep iterating until there is no more next
+    while stop_response['meta']['next'] and false
+      p stop_response['meta']['next']
+      response = HTTParty.get(stop_response['meta']['next'])
+      stop_response = JSON.parse response.body
+    end
+
+  end
+
   def human_time_taken_since(start_time)
     ms = ((TimeDifference.between(DateTime.now, start_time).in_seconds)*1000).round
 

--- a/lib/tasks/create_transit.rake
+++ b/lib/tasks/create_transit.rake
@@ -139,6 +139,8 @@ namespace :transit do
       stop_response = JSON.parse response.body
 
       stop_response['stops'].each do |stop_obj|
+        next if stop_obj['onestop_id'].include?('<')
+
         stop = Stop.new
         stop.onestop_id = stop_obj['onestop_id']
         stop.name = stop_obj['name']


### PR DESCRIPTION
This is a long time coming, and should resolve issue #20. I've added a new rake task to grab data for a transit provider from Transitland, added that info to the README, reconfigured the database to take advantage of Transitland data, and reworked line and stop display to work with transitland data.

I'm marking myself as the assignee for this pull request, as I'll be the one deploying these changes and resetting the database to get new data for the CTA from Transitland.

**Important note:** these changes deprecate importing from a raw GTFS file, as that inherently uses different fields and ways of handling data.