### PR TITLE
Hard-coded stop radius 0.5 mi -> 0.2 mi

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,7 @@
 class PagesController < ApplicationController
   def dashboard
       if ((params[:lat]) && (params[:long]))
-          @nearby_stops = Stop.includes(:lines).within(0.5, :origin => [params[:lat],params[:long]])
+          @nearby_stops = Stop.includes(:lines).within(0.2, :origin => [params[:lat],params[:long]])
       end
   end
 


### PR DESCRIPTION
Changed the hard-coded stop radius to 0.2 miles to prevent stop list crowding in dense areas. Eventually, this hardcoded radius will be replaced by a smarter system, as discussed in issue #54.