### PR TITLE
Move to Transitland Fixes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -48,7 +48,6 @@ $(document).ready(function()
 	$(".new-issue-line").change(function()
 	{
 		var self = this;
-		$(this).find("option:first-of-type").remove(); // remove default option to prevent it being submitted
 
 		$.ajax({
 		  url: "/lines/" + $(this).val() + "/get_stops",

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -17,7 +17,7 @@ class IssuesController < ApplicationController
     unless user_signed_in?
       redirect_to new_user_session_path
     end
-    @issue = Issue.new(params.permit(:stop_id, :line_id))
+    @issue = Issue.new(stop_onestop_id: params[:stop_id], line_onestop_id: params[:line_id])
   end
 
   # GET /issues/1/edit
@@ -75,6 +75,6 @@ class IssuesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def issue_params
-      params.require(:issue).permit(:types, :stop_id, :line_id, :description)
+      params.require(:issue).permit(:types, :stop_onestop_id, :line_onestop_id, :description)
     end
 end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,7 +1,7 @@
 class Issue < ApplicationRecord
   belongs_to :user
-  belongs_to :stop
+  belongs_to :stop, foreign_key: "stop_onestop_id"
   belongs_to :vehicle, required: false
-  belongs_to :line
+  belongs_to :line, foreign_key: "line_onestop_id"
   validates :types, presence: true
 end

--- a/app/models/line.rb
+++ b/app/models/line.rb
@@ -1,5 +1,5 @@
 class Line < ApplicationRecord
-  has_many :issues
+  has_many :issues, :foreign_key => 'line_onestop_id'
   has_and_belongs_to_many :stops, :foreign_key => 'line_onestop_id', :association_foreign_key => 'stop_onestop_id'
 
   self.primary_key = "onestop_id"

--- a/app/models/line.rb
+++ b/app/models/line.rb
@@ -2,6 +2,8 @@ class Line < ApplicationRecord
   has_many :issues
   has_and_belongs_to_many :stops, :foreign_key => 'line_onestop_id', :association_foreign_key => 'stop_onestop_id'
 
+  self.primary_key = "onestop_id"
+
   # Returns the longest available name
   def long_name
     route_long_name ? route_long_name : name

--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -4,6 +4,8 @@ class Stop < ApplicationRecord
   belongs_to :twin_stop, class_name: "Stop", required: false
   has_and_belongs_to_many :users
 
+  self.primary_key = "onestop_id"
+
   acts_as_mappable :default_units => :miles,
                    :default_formula => :sphere,
                    :distance_field_name => :distance,

--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -1,8 +1,8 @@
 class Stop < ApplicationRecord
-  has_many :issues
+  has_many :issues, :foreign_key => 'stop_onestop_id'
   has_and_belongs_to_many :lines, :foreign_key => 'stop_onestop_id', :association_foreign_key => 'line_onestop_id'
   belongs_to :twin_stop, class_name: "Stop", required: false
-  has_and_belongs_to_many :users
+  has_and_belongs_to_many :users, :foreign_key => 'stop_onestop_id'
 
   self.primary_key = "onestop_id"
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,5 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
   has_many :issues
-  has_and_belongs_to_many :favorites, :class_name => "Stop"
+  has_and_belongs_to_many :favorites, :class_name => 'Stop', :association_foreign_key => 'stop_onestop_id'
 end

--- a/app/views/issues/_form.html.erb
+++ b/app/views/issues/_form.html.erb
@@ -12,16 +12,16 @@
   <% end %>
 
   <div class="field-issue">
-    <%= f.label :line_id %><br>
-    <%= f.collection_select(:line_id, Line.order('vehicle_type DESC, name'), :id, :name,
+    <%= f.label 'Line' %><br>
+    <%= f.collection_select(:line_onestop_id, Line.order('vehicle_type DESC, name'), :id, :route_long_name,
       {prompt: 'Select Line'},
       {:class => "new-issue-line"}
     ) %>
   </div>
 
   <div class="field-issue">
-    <%= f.label :stop_id %><br>
-    <%= f.collection_select(:stop_id, issue.line&.stops || [], :id, :name,
+    <%= f.label 'Stop' %><br>
+    <%= f.collection_select(:stop_onestop_id, issue.line&.stops || [], :id, :name,
       {prompt: issue.line ? nil : "Select a line first"},
       {:class => "new-issue-stops"}
     ) %>

--- a/db/migrate/20170829151944_rename_stop_id_to_one_stop_id.rb
+++ b/db/migrate/20170829151944_rename_stop_id_to_one_stop_id.rb
@@ -1,0 +1,12 @@
+class RenameStopIdToOneStopId < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :stops_users, :stop_id, :stop_onestop_id
+    change_column :stops_users, :stop_onestop_id, :string # Move to string
+
+    rename_column :issues, :stop_id, :stop_onestop_id
+    change_column :issues, :stop_onestop_id, :string # Move to string
+
+    rename_column :issues, :line_id, :line_onestop_id
+    change_column :issues, :line_onestop_id, :string # Move to string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,19 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170829123148) do
+ActiveRecord::Schema.define(version: 20170829151944) do
 
   create_table "issues", force: :cascade do |t|
-    t.integer  "stop_id"
+    t.string   "stop_onestop_id"
     t.integer  "vehicle_id"
     t.text     "description"
     t.integer  "user_id"
-    t.integer  "line_id"
+    t.string   "line_onestop_id"
     t.string   "types"
     t.boolean  "resolved"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["stop_id"], name: "index_issues_on_stop_id"
+    t.index ["stop_onestop_id"], name: "index_issues_on_stop_onestop_id"
     t.index ["user_id"], name: "index_issues_on_user_id"
     t.index ["vehicle_id"], name: "index_issues_on_vehicle_id"
   end
@@ -60,8 +60,8 @@ ActiveRecord::Schema.define(version: 20170829123148) do
 
   create_table "stops_users", force: :cascade do |t|
     t.integer "user_id"
-    t.integer "stop_id"
-    t.index ["stop_id"], name: "index_stops_users_on_stop_id"
+    t.string  "stop_onestop_id"
+    t.index ["stop_onestop_id"], name: "index_stops_users_on_stop_onestop_id"
     t.index ["user_id"], name: "index_stops_users_on_user_id"
   end
 

--- a/lib/tasks/create_transit.rake
+++ b/lib/tasks/create_transit.rake
@@ -152,7 +152,6 @@ namespace :transit do
         stop.name = stop_obj['name']
         stop.longitude = stop_obj['geometry']['coordinates'][0] # takes [X, Y] format, aka [longitude, latitude]
         stop.lattitude = stop_obj['geometry']['coordinates'][1] # takes [X, Y] format, aka [longitude, latitude]
-        stop.save
       end
 
       next_url = stop_response['meta']['next']

--- a/lib/tasks/create_transit.rake
+++ b/lib/tasks/create_transit.rake
@@ -126,6 +126,11 @@ namespace :transit do
 
     agency_onestop_id = ENV["TLAND_AGENCY_ONESTOP_ID"] # fetch the onestop_id of the agency
 
+    # Setup arrays for storing data for bulk import
+    tland_lines = []
+    tland_stops = []
+    tland_lines_stops = []
+
     # View API endpoints for transitland here: https://transit.land/documentation/datastore/api-endpoints.html
     root_url = 'https://transit.land/api/v1/'
 
@@ -134,6 +139,7 @@ namespace :transit do
     response = HTTParty.get(root_url + 'stops?per_page='  + per_page.to_s + '&served_by=' + agency_onestop_id)
     i = 0
 
+    # start a loop and break when there's no 'next' link
     loop do
       puts 'Stop request ' + i.to_s
       stop_response = JSON.parse response.body
@@ -157,11 +163,16 @@ namespace :transit do
       i += 1
     end
 
+    puts 'Done requesting stops'
+
     # Iterate through routes, ignoring geometry
     response = HTTParty.get(root_url + 'routes?operated_by=' + agency_onestop_id + '&include_geometry=false')
 
+    i = 0
+
     # start a loop and break when there's no 'next' link
     loop do
+      puts 'Line request ' + i.to_s
       route_response = JSON.parse(response.body)
 
       route_response['routes'].each do |route_obj|
@@ -174,11 +185,12 @@ namespace :transit do
         line.color = route_obj['color']
         line.onestop_id = route_obj['onestop_id']
 
+        # Create an array of pair arrays of form [stop_onestop_id, line_onestop_id], used for data importing
+        lines_stops = route_obj['stops_served_by_route'].map{|hash| [hash['stop_onestop_id'], line.onestop_id]}
+        tland_lines_stops = tland_lines_stops + lines_stops
 
-        stop_onestop_ids = route_obj['stops_served_by_route'].map{|hash| hash['stop_onestop_id']}
-        line.stops = Stop.where(onestop_id: stop_onestop_ids)
-
-        line.save
+        # Add lines to bul import set of lines
+        tland_lines << line
       end
 
       next_url = route_response['meta']['next']
@@ -186,8 +198,18 @@ namespace :transit do
       break unless next_url
 
       response = HTTParty.get(next_url)
+      i += 1
     end
 
+    puts 'Done requesting lines'
+
+    # Import all lines and stops
+    Stop.import(tland_stops)
+    Line.import(tland_lines)
+
+    # Import relationships - each pair is [stop_onestop_id, line_onestop_id]
+    values = tland_lines_stops.map{|pair| '("' + pair[0].to_s + '","' + pair[1].to_s + '")' }.join(',')
+    ActiveRecord::Base.connection.execute("INSERT INTO lines_stops (stop_onestop_id, line_onestop_id) VALUES #{values}")
   end
 
   def delete_transit_data

--- a/lib/tasks/create_transit.rake
+++ b/lib/tasks/create_transit.rake
@@ -152,6 +152,8 @@ namespace :transit do
         stop.name = stop_obj['name']
         stop.longitude = stop_obj['geometry']['coordinates'][0] # takes [X, Y] format, aka [longitude, latitude]
         stop.lattitude = stop_obj['geometry']['coordinates'][1] # takes [X, Y] format, aka [longitude, latitude]
+
+        tland_stops << stop
       end
 
       next_url = stop_response['meta']['next']
@@ -185,7 +187,7 @@ namespace :transit do
         line.onestop_id = route_obj['onestop_id']
 
         # Create an array of pair arrays of form [stop_onestop_id, line_onestop_id], used for data importing
-        lines_stops = route_obj['stops_served_by_route'].map{|hash| [hash['stop_onestop_id'], line.onestop_id]}
+        lines_stops = route_obj['stops_served_by_route'].map{|h| [h['stop_onestop_id'], line.onestop_id]}
         tland_lines_stops = tland_lines_stops + lines_stops
 
         # Add lines to bul import set of lines
@@ -207,7 +209,7 @@ namespace :transit do
     Line.import(tland_lines)
 
     # Import relationships - each pair is [stop_onestop_id, line_onestop_id]
-    values = tland_lines_stops.map{|pair| '("' + pair[0].to_s + '","' + pair[1].to_s + '")' }.join(',')
+    values = tland_lines_stops.map{|pair| '("' + pair[0] + '","' + pair[1] + '")' }.join(',')
     ActiveRecord::Base.connection.execute("INSERT INTO lines_stops (stop_onestop_id, line_onestop_id) VALUES #{values}")
   end
 


### PR DESCRIPTION
This fixes the Transitland job by making it use an import instead of individual SQL calls, makes `onestop_id` the primary key of stops and lines, and then moves over issues and favorites to use this system. There are a few improvements that could be made, such as the fact that routing still uses `line_id` and `stop_id`, but this has been deployed for the sake of getting a working demo going.