### PR TITLE
Adjust Logging and Add Analytics

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,18 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
+
+    <!-- Google Analytics - tied to Viktor -->
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-39148744-4', 'auto');
+      ga('send', 'pageview');
+
+    </script>
   </head>
 
   <body>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,6 +71,12 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
+  # Use less verbose INFO logger as opposed to Rails 5 default DEBUG
+  config.log_level = :info
+
+  # Disable logging partials
+  config.action_view.logger = nil
+
   # Use a different logger for distributed setups.
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')


### PR DESCRIPTION
I've changed logging to be more concise and not log partial renders, which should help prevent us hitting Papertrail limits. I've also added Google Analytics to Transit Network, which should help us track if we're getting unusual traffic.